### PR TITLE
WIP: First steps to enabling Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,9 @@ roles:
 # Number of news stories on the front page.
 front_page_news: 8
 
+# Google Analytics
+google_analytics: G-KNFKCG89MK
+
 # make pages for the _projects folder
 collections:
   projects:

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,9 @@
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,9 @@
         <link rel="stylesheet"
               href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
         <link rel="stylesheet" href="{{ site.baseurl }}/css/group.css">
+        {% if site.google_analytics and jekyll.environment == 'production' %}
+        {% include analytics.html %}
+        {% endif %}
     </head>
     <body>
         <div class="container">
@@ -65,6 +68,9 @@
             <div class="footer">
                 <p>
 		  Our group is primarily based in the <a href="https://www.cmu.edu/">Carnegie Mellon University</a> <a href="https://www.meche.engineering.cmu.edu/">Mechanical Engineering Department</a>, with additional affiliations in <a href="https://www.cmu.edu/engineering/materials/">Materials Science and Engineering</a>, <a href="https://www.cmu.edu/physics/">Physics</a>, and <a href="https://www.cheme.engineering.cmu.edu">Chemical Engineering</a>.
+                </p>
+                <p>
+                    <a href="https://www.cmu.edu/legal/">Legal Info</a>
                 </p>
             </div>
 


### PR DESCRIPTION
Also coming in from the Incepts Website, this would enable Google Analytics
on the group website. We do need a measurement id (I can go pull one)
for the site before this can be merged.
