### PR TITLE
add Keith's personal site

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -173,7 +173,7 @@ mphuthi:
     display_name: "Mgcini Keith Phuthi"
     role: phd
     image: img/people/Keith_Phuthi.jpg
-    webpage: files/Phuthi_CV.pdf
+    webpage: https://www.andrew.cmu.edu/user/mphuthi/
     bio: Mechanical Engineering
     email: mphuthi [at] andrew [dot] cmu [dot] edu
 


### PR DESCRIPTION
previously link was directly to a CV file, now he's hosted it on an andrew site. 

Note: don't delete the file for now, as I think Venkat may have given someone that direct link for part of a fellowship application for Keith.